### PR TITLE
Readded DatabaseSeeder and updated twofaccounts migration

### DIFF
--- a/database/migrations/2023_02_21_143845_bind_twofaccounts_and_groups_to_users.php
+++ b/database/migrations/2023_02_21_143845_bind_twofaccounts_and_groups_to_users.php
@@ -15,7 +15,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('twofaccounts', function (Blueprint $table) {
-            $table->unsignedBigInteger('user_id')
+            $table->integer('user_id')
                   ->after('id')
                   ->nullable();
 
@@ -23,7 +23,7 @@ return new class extends Migration
         });
 
         Schema::table('groups', function (Blueprint $table) {
-            $table->unsignedBigInteger('user_id')
+            $table->integer('user_id')
                   ->after('id')
                   ->nullable();
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // Ability to seed data for testing purposes
+        //$this->call([
+        //    DemoSeeder::class,
+        //    TestingSeeder::class
+        //]);
+    }
+}


### PR DESCRIPTION
Readded DatabaseSeeder to remove DatabaseSeeder errors. If testing needs to be done, using `php artisan migrate --seed`

Updated `2023_02_21_143845_bind_twofaccounts_and_groups_to_users.php` migration which solves the foreign key errors when using mysql database.

Solves Error #175 

sqlite migrations are unaffected during tests.