### PR TITLE
Fix logo size overflow

### DIFF
--- a/resources/js/components/OtpDisplay.vue
+++ b/resources/js/components/OtpDisplay.vue
@@ -317,7 +317,7 @@
 
 <template>
     <div>
-        <figure class="image is-64x64" :class="{ 'no-icon': !otpauthParams.icon }" style="display: inline-block">
+        <figure class="image is-64x64" :class="{ 'no-icon': !otpauthParams.icon }" style="display: inline-flex">
             <img :src="$2fauth.config.subdirectory + '/storage/icons/' + otpauthParams.icon" v-if="otpauthParams.icon" :alt="$t('twofaccounts.icon_to_illustrate_the_account')">
         </figure>
         <UseColorMode v-slot="{ mode }">


### PR DESCRIPTION
Fixed a small styling issue where logos that are not squared overlap with the text.

Before:
![bf](https://github.com/user-attachments/assets/cb3c2f32-a780-4d70-9a00-0a00384577f2)

After:
![af](https://github.com/user-attachments/assets/7c6a270e-d601-4fd2-abf4-83006f6cb8b1)
