### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Sensitive data stored in the database can be encrypted to protect them against d
 
 ## Installation guides
 
+* [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/2fauth) one-click managed hosting, no server required
+
 * [Self-hosted server](https://docs.2fauth.app/getting-started/installation/self-hosted-server/)
 
 * [Docker (cli)](https://docs.2fauth.app/getting-started/installation/docker/docker-cli/)


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added 2FAuth to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Installation guides section (links to https://zenith.hosting/host/2fauth).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting